### PR TITLE
throw MethodError for things we can't display

### DIFF
--- a/src/EmacsVterm.jl
+++ b/src/EmacsVterm.jl
@@ -62,6 +62,7 @@ function Base.display(d::Display, x)
             return display(d, mime, x)
         end
     end
+    throw(MethodError(display, (d, x)))
 end
 
 """


### PR DESCRIPTION
On `main`, stuff like 1+1 does not display when `image = true`. This fixes that.